### PR TITLE
Add parseMaxBracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Parses the source until the first unmatched close bracket (any of `)`, `}`, `]`)
 }
 ```
 
+### parseMaxBracket(src, bracket, options = {start: 0})
+
+Parses the source until the first unmatched specified `bracket` (any of `)`, `}`, `]`). It returns an object with the structure:
+
+```js
+{
+  start: 0,//index of first character of string
+  end: 13,//index of first character after the end of string
+  src: 'source string'
+}
+```
+
 ### parseUntil(src, delimiter, options = {start: 0, includeLineComment: false})
 
 Parses the source until the first occurence of `delimiter` which is not in a string or a comment.  If `includeLineComment` is `true`, it will still count if the delimiter occurs in a line comment, but not in a block comment.  It returns an object with the structure:

--- a/index.js
+++ b/index.js
@@ -35,6 +35,36 @@ function parseMax(src, options) {
   };
 }
 
+var bracketToProp = {
+  ')': 'roundDepth',
+  '}': 'curlyDepth',
+  ']': 'squareDepth'
+};
+
+exports.parseMaxBracket = parseMaxBracket;
+function parseMaxBracket(src, bracket, options) {
+  options = options || {};
+  var start = options.start || 0;
+  var index = start;
+  var state = exports.defaultState();
+  var prop = bracketToProp[bracket];
+  if (prop === undefined) {
+    throw new Error('Bracket specified (' + JSON.stringify(bracket) + ') is not one of ")", "]", or "}";');
+  }
+  while (state[prop] >= 0) {
+    if (index >= src.length) {
+      throw new Error('The end of the string was reached with no closing bracket "' + bracket + '" found.');
+    }
+    exports.parseChar(src[index++], state);
+  }
+  var end = index - 1;
+  return {
+    start: start,
+    end: end,
+    src: src.substring(start, end)
+  };
+}
+
 exports.parseUntil = parseUntil;
 function parseUntil(src, delimiter, options) {
   options = options || {};
@@ -53,7 +83,6 @@ function parseUntil(src, delimiter, options) {
     src: src.substring(start, end)
   };
 }
-
 
 exports.parseChar = parseChar;
 function parseChar(character, state) {

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,18 @@ it('finds contents of bracketed expressions', function () {
   assert(section.src === 'foo="(", bar="}"');
 });
 
+it('finds contents of bracketed expressions with specified bracket', function () {
+  var section = parser.parseMaxBracket('foo="(", bar="}")] bing bong', ']');
+  assert(section.start === 0);
+  assert(section.end === 17);//exclusive end of string
+  assert(section.src === 'foo="(", bar="}")');
+
+  var section = parser.parseMaxBracket('foo="(", bar="}")] bing bong', ')');
+  assert(section.start === 0);
+  assert(section.end === 16);//exclusive end of string
+  assert(section.src === 'foo="(", bar="}"');
+});
+
 it('finds code up to a custom delimiter', function () {
   var section = parser.parseUntil('foo.bar("%>").baz%> bing bong', '%>');
   assert(section.start === 0);


### PR DESCRIPTION
This is similar to `parseMax`, but allows all brackets in `src` except for the one specified.