### PR TITLE
feat: add es-module output

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,23 @@
   "description": "Parse JavaScript one character at a time to look for snippets in Templates.  This is not a validator, it's just designed to allow you to have sections of JavaScript delimited by brackets robustly.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": [
+      {
+        "import": "./lib/index.mjs",
+        "require": "./lib/index.js",
+        "default": "./lib/index.js"
+      },
+      "./lib/index.js"
+    ]
+  },
   "files": [
     "lib"
   ],
   "scripts": {
     "pretest": "npm run build",
     "prepublishOnly": "npm run build",
-    "build": "tsc",
-    "coverage": "istanbul cover test/index.js",
+    "build": "tsc && tsc -p tsconfig.modules.json && mv lib-next/index.js lib/index.mjs && rimraf lib-next",
     "test": "node test/index.js"
   },
   "repository": {
@@ -31,7 +40,7 @@
   "author": "ForbesLindesay",
   "license": "MIT",
   "devDependencies": {
-    "istanbul": "~0.4.5",
+    "rimraf": "^3.0.2",
     "testit": "~3.1.0",
     "typescript": "^4.5.4"
   },

--- a/tsconfig.modules.json
+++ b/tsconfig.modules.json
@@ -1,0 +1,9 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "lib-next",
+    "strict": true,
+    "target": "ES2020"
+  }
+}


### PR DESCRIPTION
This adds a `.mjs` file in the es-module format, alongside the existing CommonJS file.